### PR TITLE
removes build from root level of jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ docs: build
 lib: build
 	rm -rf lib
 	mkdir lib
-	jar cvf lib/cs50.jar build/*
+	jar cvf lib/cs50.jar -C build .
 
 clean:
 	rm -rf build docs lib


### PR DESCRIPTION
`make lib` ends up creating a `jar` containing the `build` directory in its root
level which would require importing `build.edu.harvard.CS50` instead of just
`edu.harvard.CS50`.

this fixes the problem by specifying that the `jar` should have `edu` in its
root level.
