### PR TITLE
supported java7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk7
 dist: trusty
 sudo: required
 branches:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DESTDIR ?= /usr/local/share/java
-VERSION = 2.0.1
+VERSION = 2.0.2
 
 .PHONY: build
 build: clean Makefile src/edu/harvard/CS50.java


### PR DESCRIPTION
Travis uses Java 8 by default, and `javac` produces bytecode that's forward-compatible only by default per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=673276!